### PR TITLE
Updated intl to ^0.20.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.19.0
+  intl: ^0.20.2
   video_player: ^2.8.2
   cached_network_image: ^3.3.1
 


### PR DESCRIPTION
Updated intl dependency from ^0.19.0 to ^0.20.2 to ensure compatibility with the latest Flutter versions.
This resolves version conflict issues.
